### PR TITLE
Fix game list acquisition

### DIFF
--- a/games.go
+++ b/games.go
@@ -36,7 +36,7 @@ type Game struct {
 
 // Pattern of game declarations in the public profile. It's actually JSON
 // inside Javascript, but this way is easier to extract.
-const profileGamePattern = `\{"appid":\s*(\d+),\s*"name":\s*"(.+?)"`
+const profileGamePattern = `<appID>(\d+)<\/appID>\s*<name><!\[CDATA\[(.+?)\]\]><\/name>`
 
 // Fetches the list of games from the public user profile. This is better than
 // looking locally because the profiles give the full game name, which can be

--- a/users.go
+++ b/users.go
@@ -84,7 +84,7 @@ func GetUsers(installationDir string) ([]User, error) {
 }
 
 // URL to get the game list from the SteamId64.
-const profilePermalinkFormat = `http://steamcommunity.com/profiles/%v/games?tab=all`
+const profilePermalinkFormat = `http://steamcommunity.com/profiles/%v/games?xml=1`
 
 // The Steam website has the terrible habit of returning 200 OK when requests
 // fail, and signaling the error in HTML. So we have to parse the request to


### PR DESCRIPTION
Accessing the games tab apparently requires being logged in to Steam, but requesting the list in XML format still works